### PR TITLE
create library.properties via gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 build/
+libs/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .gradle
 build/
 libs/
+release/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/

--- a/README.md
+++ b/README.md
@@ -1,28 +1,71 @@
-# Processing Library Template
-
-A prototype for a template for developing Processing libraries. This is a project of 
-the 2024 New Beginnings (pr05) Grant from the Processing Foundation, to simplify the 
-workflows for libraries, tools, and modes, mentored by [@Stefterv](https://github.com/stefterv). This template is 
-based on Intellij IDE and Gradle for building and releasing the library. It is also 
-heavily based on the following two existing Processing library templates, also based 
-on Intellij and Gradle.
-
-- https://github.com/processing/processing-library-template-gradle
-- https://github.com/enkatsu/processing-library-template-gradle
-
-I also wish to thank the developers of these repositories, who generously provided 
-guidance and time. This template has been developed in collaboration with 
-[@enkatsu](https://github.com/enkatsu).
+# Processing Library Template [WIP]
+This is a template for developing Processing libraries. This template is built and released
+with Gradle.
 
 ## How to use
-This repository is designed to be built with Gradle. The best IDE experience is with
-Intellij.
 
-This repository can be built as is. On the right menu bar in Intellij, there is a 
-Gradle menu. Toggle `Tasks` > `processing` and two tasks will be listed below:
-- `releaseProcessingLib` creates the release artifacts in the `release` folder
-- `copyToLocalProcessing` will copy the contents of the release folder into the relevant
+### Development
+1. **Use this repository as a template repository.** Look for a highlighted button to the top right 
+with the words "Use this template." Select "Create a new repository" and then name your repository as 
+something else, as you'd like.
+2. This repository will build as is. Feel free to test the release how-to, to get a sense of what
+to expect with those steps.
+3. **Define the short name of your library as the `rootProject.name` in `settings.gradle.kts`.**
+   The "short name" is the name of your library, without the domain.
+   It will also be used to name the folder in the Processing sketchbook that holds the library files,
+   and the release zip file.
+4. **Define the `group` and `version` of your library in `build.gradle.kts`.** The group is your
+domain, in reverse. The standard for version strings is semantic version (semver).
+5. **Define the location of your sketchbook folder.** This facilitates testing of your library
+in Processing. If you wish to resolve a dependency on a locally installed Processing library,
+you will also need to set file path.
+6. **Add dependencies in the `dependencies` block in `build.gradle.kts`.** 
+The sample library code  uses the following remote dependency that is resolved with maven:
+   ```
+   implementation("org.apache.commons:commons-math3:3.6.1")
+   ```
+   Add your own dependencies using the same structure. After you add these dependencies, you can 
+build with Gradle to download them to the `libs` folder, and then you will be able to import them
+in your code. Dependencies added to the `implementation` "configuration" will be included in the 
+release as jars. Dependencies added to the `compileOnly` configuration, such as Processing core, are 
+available for compilation, but won't be included in the release as jars. If you want to import 
+libraries released on Github using jitpack, jitpack is already included as a repository.
+4. **Develop your library within `src/main/java/`.** Set the `package` to your own domain and name,
+and set the version. Processing libraries are required to return the current installed version.
+
+
+
+### Release
+1. Fill in the file `release.properties` with information for your library. This information will be
+used to create the required `library.properties` file, done by a Gradle task.
+2. **To build the library and create the release artifacts run the Gradle task `releaseProcessingLib`.** 
+This task will create a `release` folder with needed artifacts. On the right menu bar in Intellij, 
+there is a Gradle menu. Toggle `Tasks` > `processing` and double click `releaseProcessingLib`. This 
+task has bundled the following required tasks:
+   1. `build` task: this bundles a number of build tasks, including the `jar` task which creates a 
+   jar file. all build artifacts are in the folder `build`.
+   2. documentation build. 
+   3. creation of the `library.properties` file: this file is built from the properties set in the 
+   `release.properties` file, plus the version, in the task `writeLibraryProperties`.
+   4. within the `releaseProcessingLib` task, the `release` folder is created, jars of the library and
+   dependencies are copied, and the `library.properties` file is copied. Also, a zip file is made.
+3.`copyToLocalProcessing` will copy the contents of the release folder into the relevant
 folder in the sketchbook folder, a folder that Processing creates that holds your installed
-libraries, among other things.
+libraries, among other things. This installs your library into Processing, and you can test
+the release with your examples.
 
-TO run a task, double click on it.
+
+## Contributors
+
+This template was created as part of the 2024 New Beginnings (pr05) Grant from the 
+[Processing Foundation](https://github.com/processing), to simplify the
+workflows for libraries, tools, and modes, mentored by [@Stefterv](https://github.com/stefterv).
+
+It is based on and inspired by a number of Processing library templates, including:
+- https://github.com/processing/processing-library-template-gradle
+- https://github.com/enkatsu/processing-library-template-gradle
+- https://github.com/hamoid/processing-library-template/
+
+I wish to thank the developers of these repositories, who generously provided
+guidance and time. This template has been developed in collaboration with
+[@enkatsu](https://github.com/enkatsu).

--- a/README.md
+++ b/README.md
@@ -16,10 +16,7 @@ to expect with those steps.
    and the release zip file.
 4. **Define the `group` and `version` of your library in `build.gradle.kts`.** The group is your
 domain, in reverse. The standard for version strings is semantic version (semver).
-5. **Define the location of your sketchbook folder.** This facilitates testing of your library
-in Processing. If you wish to resolve a dependency on a locally installed Processing library,
-you will also need to set file path.
-6. **Add dependencies in the `dependencies` block in `build.gradle.kts`.** 
+5. **Add dependencies in the `dependencies` block in `build.gradle.kts`.** 
 The sample library code  uses the following remote dependency that is resolved with maven:
    ```
    implementation("org.apache.commons:commons-math3:3.6.1")
@@ -30,7 +27,7 @@ in your code. Dependencies added to the `implementation` "configuration" will be
 release as jars. Dependencies added to the `compileOnly` configuration, such as Processing core, are 
 available for compilation, but won't be included in the release as jars. If you want to import 
 libraries released on Github using jitpack, jitpack is already included as a repository.
-4. **Develop your library within `src/main/java/`.** Set the `package` to your own domain and name,
+6. **Develop your library within `src/main/java/`.** Set the `package` to your own domain and name,
 and set the version. Processing libraries are required to return the current installed version.
 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,6 @@
 import java.util.Properties
+import org.gradle.internal.os.OperatingSystem
+
 
 plugins {
     id("java")
@@ -17,13 +19,16 @@ version = "1.0.0"
 // It is needed only if you
 // 1. wish to copy the library to the Processing sketchbook, such that you can import it in Processing
 // 2. have Processing library dependencies
-//
-// System.getProperty("user.home") is your home directory
-// Windows: System.getProperty("user.home")+"/My Documents/Processing/sketchbook"
-// Mac: System.getProperty("user.home")+"/Documents/Processing/sketchbook"
-// Linux: System.getProperty("user.home")+"/sketchbook"
-// If these do not work, check the sketchbook location in your Processing application preferences.
-val sketchbookLocation = System.getProperty("user.home")+"/sketchbook"
+// You can check the sketchbook location in your Processing application preferences.
+var sketchbookLocation = ""
+if(OperatingSystem.current().isMacOsX) {
+    sketchbookLocation = System.getProperty("user.home")+"/Documents/Processing/sketchbook"
+} else if(OperatingSystem.current().isWindows) {
+    sketchbookLocation = System.getProperty("user.home")+"/My Documents/Processing/sketchbook"
+} else {
+    sketchbookLocation = System.getProperty("user.home")+"/sketchbook"
+}
+println("sketchbook location: $sketchbookLocation")
 
 // the short name of your library. This string will name relevant files and folders.
 // Such as:
@@ -31,7 +36,6 @@ val sketchbookLocation = System.getProperty("user.home")+"/sketchbook"
 // <libName>.zip will be the name of your release file
 // this name defaults to the rootProject.name
 val libName = rootProject.name
-
 
 java {
     toolchain {
@@ -54,7 +58,6 @@ dependencies {
     // insert your external dependencies
     // TODO actually use dependency in library
     implementation("org.apache.commons:commons-math3:3.6.1")
-    implementation("org.json:json:20240303")
 
     // To add a dependency on a Processing library that is installed locally,
     // uncomment the line below, and replace <library folder> with the location of that library

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,23 +7,31 @@ plugins {
 //==========================
 // USER BUILD CONFIGURATIONS
 
-// the short name of your library. This string will name relevant files and folders.
-// Such as:
-// <libName>.jar will be the name of your build jar
-// <libName>.zip will be the name of your release file
-val libName = rootProject.name
-
-// location of your sketchbook folder, required only if you
-// 1. wish to copy the library to the Processing sketchbook, such that you can import it in Processing
-// 2. have Processing library dependencies
-val sketchbookLocation by extra(System.getProperty("user.home")+"/sketchbook")
-
-
 // group id of your library. Often is reverse domain
 group = "com.example"
 
 // version of library, usually semver
 version = "1.0.0"
+
+// The location of your sketchbook folder. The sketchbook folder holds your installed libraries, tools, and modes
+// It is needed only if you
+// 1. wish to copy the library to the Processing sketchbook, such that you can import it in Processing
+// 2. have Processing library dependencies
+//
+// System.getProperty("user.home") is your home directory
+// Windows: System.getProperty("user.home")+"/My Documents/Processing/sketchbook"
+// Mac: System.getProperty("user.home")+"/Documents/Processing/sketchbook"
+// Linux: System.getProperty("user.home")+"/sketchbook"
+// If these do not work, check the sketchbook location in your Processing application preferences.
+val sketchbookLocation = System.getProperty("user.home")+"/sketchbook"
+
+// the short name of your library. This string will name relevant files and folders.
+// Such as:
+// <libName>.jar will be the name of your build jar
+// <libName>.zip will be the name of your release file
+// this name defaults to the rootProject.name
+val libName = rootProject.name
+
 
 java {
     toolchain {
@@ -46,6 +54,7 @@ dependencies {
     // insert your external dependencies
     // TODO actually use dependency in library
     implementation("org.apache.commons:commons-math3:3.6.1")
+    implementation("org.json:json:20240303")
 
     // To add a dependency on a Processing library that is installed locally,
     // uncomment the line below, and replace <library folder> with the location of that library
@@ -71,16 +80,32 @@ tasks.test {
 //============================
 // Tasks for releasing library
 
-val libraryProperties = Properties().apply {
-    load(rootProject.file("library.properties").inputStream())
-}
-
-val userHome = System.getProperty("user.home")
-val libVersion = libraryProperties.getProperty("version")
-
 val releaseRoot = "$rootDir/release"
 val releaseName = libName
 val releaseDirectory = "$releaseRoot/$releaseName"
+
+// read in user-defined properties in release.properties file
+// to be saved in library.properties file, a required file in the release
+// using task writeLibraryProperties
+val libraryProperties = Properties().apply {
+    load(rootProject.file("release.properties").inputStream())
+}
+
+tasks.register<WriteProperties>("writeLibraryProperties") {
+    group = "processing"
+    destinationFile = project.file("library.properties")
+
+    property("name", libraryProperties.getProperty("name"))
+    property("version", libraryProperties.getProperty("version"))
+    property("prettyVersion", project.version)
+    property("authors", libraryProperties.getProperty("authors"))
+    property("url", libraryProperties.getProperty("url"))
+    property("categories", libraryProperties.getProperty("categories"))
+    property("sentence", libraryProperties.getProperty("sentence"))
+    property("paragraph", libraryProperties.getProperty("paragraph"))
+    property("minRevision", libraryProperties.getProperty("minRevision"))
+    property("maxRevision", libraryProperties.getProperty("maxRevision"))
+}
 
 // define the order of running, to ensure clean is run first
 tasks.build.get().mustRunAfter("clean")
@@ -88,7 +113,7 @@ tasks.javadoc.get().mustRunAfter("build")
 
 tasks.register("releaseProcessingLib") {
     group = "processing"
-    dependsOn("clean","build","javadoc")
+    dependsOn("clean","build","javadoc", "writeLibraryProperties")
     finalizedBy("packageRelease")
 
     doFirst {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,21 +15,6 @@ group = "com.example"
 // version of library, usually semver
 version = "1.0.0"
 
-// The location of your sketchbook folder. The sketchbook folder holds your installed libraries, tools, and modes
-// It is needed only if you
-// 1. wish to copy the library to the Processing sketchbook, such that you can import it in Processing
-// 2. have Processing library dependencies
-// You can check the sketchbook location in your Processing application preferences.
-var sketchbookLocation = ""
-if(OperatingSystem.current().isMacOsX) {
-    sketchbookLocation = System.getProperty("user.home")+"/Documents/Processing/sketchbook"
-} else if(OperatingSystem.current().isWindows) {
-    sketchbookLocation = System.getProperty("user.home")+"/My Documents/Processing/sketchbook"
-} else {
-    sketchbookLocation = System.getProperty("user.home")+"/sketchbook"
-}
-println("sketchbook location: $sketchbookLocation")
-
 // the short name of your library. This string will name relevant files and folders.
 // Such as:
 // <libName>.jar will be the name of your build jar
@@ -86,6 +71,22 @@ tasks.test {
 val releaseRoot = "$rootDir/release"
 val releaseName = libName
 val releaseDirectory = "$releaseRoot/$releaseName"
+
+// The location of your sketchbook folder. The sketchbook folder holds your installed libraries, tools, and modes
+// It is needed only if you
+// 1. wish to copy the library to the Processing sketchbook, such that you can import it in Processing
+// 2. have Processing library dependencies
+// You can check the sketchbook location in your Processing application preferences.
+var sketchbookLocation = ""
+val userHome = System.getProperty("user.home")
+val currentOS = OperatingSystem.current()
+if(currentOS.isMacOsX) {
+    sketchbookLocation = "$userHome/Documents/Processing/sketchbook"
+} else if(currentOS.isWindows) {
+    sketchbookLocation = "$userHome/My Documents/Processing/sketchbook"
+} else {
+    sketchbookLocation = "$userHome/sketchbook"
+}
 
 // read in user-defined properties in release.properties file
 // to be saved in library.properties file, a required file in the release

--- a/release.properties
+++ b/release.properties
@@ -4,6 +4,12 @@
 # The name of your Library as you want it formatted.
 name=Hello Library
 
+# A version number that increments once with each release. This is used to
+# compare different versions of the same Library, and check if an update is
+# available. You should think of it as a counter, counting the total number of
+# releases you've had. NOTE: This must be parsable as an int!
+version=1
+
 # List of authors. Links can be provided using the syntax [author name](url).
 authors=[Your Name](https://your.website.com)
 
@@ -36,16 +42,6 @@ paragraph=
 # Links in the 'sentence' and 'paragraph' attributes can be inserted using the
 # same syntax as for authors. 
 # That is, [here is a link to Processing](http://processing.org/)
-
-# A version number that increments once with each release. This is used to 
-# compare different versions of the same Library, and check if an update is 
-# available. You should think of it as a counter, counting the total number of 
-# releases you've had. NOTE: This must be parsable as an int!
-version=1
-
-# The version as the user will see it. If blank, the version attribute will be 
-# used here. This should be a single word, with no spaces. This is treated as a String
-prettyVersion=
 
 # The min and max revision of Processing compatible with your Library.
 # Note that these fields use the revision and not the version of Processing, 


### PR DESCRIPTION
The library.properties file is now generated by gradle. This strips the comments, and also outputs the properties in alphabetical order.

The library.properties file has been renamed to release.properties. The prettyVersion entry though has been deleted, because it is redundant with the project version.

There are also new instructions in the readme.